### PR TITLE
All inclusion of other jest-playwright options.

### DIFF
--- a/packages/nx-jest-playwright/src/executors/jest-playwright/executor.ts
+++ b/packages/nx-jest-playwright/src/executors/jest-playwright/executor.ts
@@ -54,6 +54,7 @@ async function runJest(
     testEnvironmentOptions: {
       ...(testEnvironmentOptions as Record<string, unknown>),
       'jest-playwright': {
+        ...jestPlaywrightOptions,
         browsers: browsers ?? jestPlaywrightOptions.browsers,
         launchOptions: {
           ...jestPlaywrightLaunchOptions,


### PR DESCRIPTION
This change allows you to specify additional jest-playwright options. Prior to this change only `launchOptions` were supported.

See https://github.com/playwright-community/jest-playwright#options