### PR TITLE
fix: pass watch option to JEST runner

### DIFF
--- a/packages/nx-jest-playwright/src/executors/jest-playwright/executor.ts
+++ b/packages/nx-jest-playwright/src/executors/jest-playwright/executor.ts
@@ -49,7 +49,7 @@ async function runJest(
   const jestPlaywrightOptions = testEnvironmentOptions['jest-playwright'] || {};
   const jestPlaywrightLaunchOptions = jestPlaywrightOptions.launchOptions || {};
 
-  const config = {
+  const config: Config.Argv = {
     ...parsedConfig,
     globals: JSON.stringify({ ...globals, baseUrl }),
     testEnvironmentOptions: {
@@ -66,6 +66,8 @@ async function runJest(
         },
       },
     },
+    watch: options.watch,
+    watchAll: options.watchAll,
   };
 
   const { results } = await runCLI(config, [options.jestConfig]);


### PR DESCRIPTION
Hi,

Currently running in watch mode does not trigger watch in JEST - executor just run forever, but any edit of spec do not run testing again. Passing source "watch" option to JEST executor fixes this issue