### PR TITLE
Do not give `watch` to `devServerTarget` executor if the parameter was not defined

### DIFF
--- a/packages/nx-jest-playwright/src/executors/jest-playwright/lib/start-dev-server.ts
+++ b/packages/nx-jest-playwright/src/executors/jest-playwright/lib/start-dev-server.ts
@@ -22,7 +22,7 @@ export async function* startDevServer(
 
   for await (const output of await runExecutor<ExecutorResult>(
     { project, target, configuration },
-    { watch },
+    watch ? { watch } : {},
     context,
   )) {
     if (!output.success && !watch) {


### PR DESCRIPTION
We want to use `nx-jest-playwright` to test an application that uses serverside rendering with angular universal. 

In the testee app, our target to serve the app with SSR locally looks like this:

```json
    "serve-ssr": {
      "executor": "@nguniversal/builders:ssr-dev-server",
      "configurations": {
        // ...
      },
      "defaultConfiguration": "development"
    }
```

When we look into the schema of the `@nguniversal/builders:ssr-dev-server` we can see that it has no `watch` parameter. That makes sense, because this target this executor whould intrinsically behave "watchy", because it builds the source code, then runs a node server and serves the app, and rebuilds / restarts the server when there are any changes to the source code.

However, because the executor named above, does not have `watch` in its schema, we ran into a problem when we used our `serve-ssr` target, named above, as `devServerTarget` in our e2e-app, like this:

```json
    "e2e": {
      "executor": "@ns3/nx-jest-playwright:jest-playwright",
      "options": {
        "devServerTarget": "editorial-www-m3:serve-ssr", // <-- Here
        "jestConfig": "apps/editorial-e2e/jest.config.js",
        "passWithNoTests": true
      },
      "configurations": {
        "production": {
          "devServerTarget": "editorial-www-m3:serve-ssr:production"
        }
      }
    },
```

If we run the `e2e` target now, we get the following error: 

`'watch' is not found in schema`

The root of this error is, like described above, that the `@nguniversal/builders:ssr-dev-server` has no "watch" parameter in its schema. Still, `@ns3/nx-jest-playwright:jest-playwright` gives this parameter to the executee executor, even if `watch` is undefined.

This pull request fixes the error, by only adding `watch` to the target configuration if it's not falsy.