### PR TITLE
Update get-sls-command.ts

### DIFF
--- a/packages/nx-serverless/src/utils/get-sls-command.ts
+++ b/packages/nx-serverless/src/utils/get-sls-command.ts
@@ -4,7 +4,6 @@ export function getSlsCommand() {
   const packageManager = detectPackageManager();
   switch (packageManager) {
     case 'pnpm':
-      return 'sls';
     case 'yarn':
     case 'npm':
     default:


### PR DESCRIPTION
Use npm for all package managers

This can be done since all package managers depend on NodeJS being installed

Fixes #90