### PR TITLE
fix: fix combined packaging in serverless plugin

### DIFF
--- a/packages/nx-serverless/plugin/packaging/packaging-manager.ts
+++ b/packages/nx-serverless/plugin/packaging/packaging-manager.ts
@@ -53,10 +53,10 @@ export class PackagingManager {
     const destination = this.generateFunctionCombinedPath();
     functions.forEach((func) => {
       func.setArtifactPath(destination);
-      files.push(this.findFunctionFiles(func, outputAbsolutePath));
-      assets.push(this.findAssets(func));
+      files.push(...this.findFunctionFiles(func, outputAbsolutePath));
+      assets.push(...this.findAssets(func));
     });
-    assets.push(this.findCommonAssets());
+    assets.push(...this.findCommonAssets());
     const uniqueAssets = [...new Set(assets)];
     await this.putAssetsNextToFunctionFiles(uniqueAssets, outputAbsolutePath);
 


### PR DESCRIPTION
When generating serverless package with `package.individually` set to false, the plugin would crash due to an error in the asset collection logic.