### PR TITLE
Local plugin demo

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -66,5 +66,6 @@
     ]
   },
   "nxCloudAccessToken": "YzQ0ZjZiNmItNDVjMi00OTVkLWI0YTMtZTJjYjBhZDE0YWEwfHJlYWQtd3JpdGU=",
-  "parallel": 1
+  "parallel": 1,
+  "plugins": ["@ns3/nx-core/src/plugin"]
 }

--- a/packages/nx-core/src/plugin.ts
+++ b/packages/nx-core/src/plugin.ts
@@ -1,0 +1,16 @@
+import { CreateNodes, CreateNodesContext, readJsonFile } from '@nx/devkit';
+
+export const createNodes: CreateNodes = [
+  '**/project.json',
+  (projectConfigurationFile: string, opts, context: CreateNodesContext) => {
+    const projectConfiguration = readJsonFile(projectConfigurationFile);
+
+    console.log('projectConfiguration.name', projectConfiguration);
+
+    return {
+      projects: {
+        [projectConfiguration.name]: projectConfiguration,
+      },
+    };
+  },
+];


### PR DESCRIPTION
PR to showcase using locally defined plugins in `nx.json`

When running: `NX_CACHE_PROJECT_GRAPH=false NX_DAEMON=false npx nx graph`

It fails with:
```
Plugin listed in `nx.json` not found: @ns3/nx-core/src/plugin

 >  NX   Cannot find module '@ns3/nx-core/src/plugin'
```

---

Links:
* https://nx.dev/extending-nx/recipes/project-graph-plugins
* https://www.youtube.com/watch?v=wADNsVItnsM

```
Thanks, I have created a sample PR showcasing the issue: https://github.com/Bielik20/nx-plugins/pull/106
```